### PR TITLE
Learnerの訳語を修正

### DIFF
--- a/manuscript/01.3-ml-definitions.Rmd
+++ b/manuscript/01.3-ml-definitions.Rmd
@@ -142,7 +142,7 @@ knitr::include_graphics("images/programing-ml.png")
 A **Learner** or **Machine Learning Algorithm** is the program used to learn a machine learning model from data.
 Another name is "inducer" (e.g. "tree inducer").
 -->
-**学習者 (Learner)** または **機械学習アルゴリズム** はデータから機械学習モデルを学習するためのプログラムのことを言います。別の名前は、”inducer” (例えば, “tree inducer”)とも言います。
+**学習器 (Learner)** または **機械学習アルゴリズム** はデータから機械学習モデルを学習するためのプログラムのことを言います。別の名前は、”inducer” (例えば, “tree inducer”)とも言います。
 
 <!--
 A **Machine Learning Model** is the learned program that maps inputs to predictions.
@@ -156,7 +156,7 @@ In formulas, the trained machine learning model is called $\hat{f}$ or $\hat{f}(
 <!--
 fig.cap = "A learner learns a model from labeled training data. The model is used to make predictions."
 -->
-```{r learner-definition, fig.cap = "ラベル付きの学習データから学習者がモデルを学習する様子 モデルは予測を行うために使用される。", echo = FALSE, width = 500}
+```{r learner-definition, fig.cap = "ラベル付きの学習データから学習器がモデルを学習する様子 モデルは予測を行うために使用される。", echo = FALSE, width = 500}
 knitr::include_graphics("images/learner.png")
 ```
 


### PR DESCRIPTION
Learnerの訳語を学習者としていますが、学習器と訳すのが一般的かと思われます。

参考URL
https://kotobank.jp/word/%E5%AD%A6%E7%BF%92%E5%99%A8-2121614
